### PR TITLE
fikset på logikk for maks fart på taxiway

### DIFF
--- a/brusOgPotetgull.airportLiberary/AirportComponents/Taxiway.cs
+++ b/brusOgPotetgull.airportLiberary/AirportComponents/Taxiway.cs
@@ -72,10 +72,13 @@ namespace brusOgPotetgull.airportLiberary
             while (remainingDistance > 0)
             {
                 remainingDistance = remainingDistance - currentSpeed;
-                currentSpeed += aircraft.AccelerationOnGround;
-                if (currentSpeed > MaxSpeed)
+                if (currentSpeed == 0)
                 {
-                    currentSpeed = MaxSpeed;
+                    currentSpeed += aircraft.AccelerationOnGround;
+                }
+                if (currentSpeed <= MaxSpeed & currentSpeed <= aircraft.MaxSpeedOnGround)
+                {
+                    currentSpeed += aircraft.AccelerationOnGround;
                 }
                 secondCounter++;
                 Console.WriteLine(currentSpeed);


### PR DESCRIPTION
fly kan nå ikke lenger gå raskere en fartsgrensen eller sin egen kapasitet på taxiways